### PR TITLE
strip out syslog repeat messages

### DIFF
--- a/tail.sh
+++ b/tail.sh
@@ -46,6 +46,7 @@ fi
       --follow \
       --json | \
     jq -cr '.events[]|"hostname=" + .hostname + " " + .message' | \
+    perl -lape 's/message repeated \d+ times: \[ (.*)\]/$1/g' | \
     honeytail \
       --writekey="$HONEYCOMB_WRITEKEY" \
       --dataset="$HONEYCOMB_DATASET" \
@@ -76,6 +77,7 @@ sleep $BOOT_DELAY
       --follow \
       --json | \
     jq -cr '.events[]|"hostname=" + .hostname + " " + .message' | \
+    perl -lape 's/message repeated \d+ times: \[ (.*)\]/$1/g' | \
     honeytail \
       --writekey="$HONEYCOMB_WRITEKEY" \
       --dataset="$HONEYCOMB_DATASET" \
@@ -107,6 +109,7 @@ sleep $BOOT_DELAY
       --follow \
       --json | \
     jq -cr '.events[]|"hostname=" + .hostname + " " + .message' | \
+    perl -lape 's/message repeated \d+ times: \[ (.*)\]/$1/g' | \
     honeytail \
       --writekey="$HONEYCOMB_WRITEKEY" \
       --dataset="$HONEYCOMB_DATASET" \
@@ -137,6 +140,7 @@ sleep $BOOT_DELAY
       --follow \
       --json | \
     jq -cr '.events[]|"hostname=" + .hostname + " " + .message' | \
+    perl -lape 's/message repeated \d+ times: \[ (.*)\]/$1/g' | \
     honeytail \
       --writekey="$HONEYCOMB_WRITEKEY" \
       --dataset="$HONEYCOMB_DATASET" \
@@ -167,6 +171,7 @@ sleep $BOOT_DELAY
       --follow \
       --json | \
     jq -cr '.events[]|"hostname=" + .hostname + " " + .message' | \
+    perl -lape 's/message repeated \d+ times: \[ (.*)\]/$1/g' | \
     honeytail \
       --writekey="$HONEYCOMB_WRITEKEY" \
       --dataset="$HONEYCOMB_DATASET" \


### PR DESCRIPTION
after last night's rabbit incident i saw some garbage fields in honeycomb again. i was able to correlate those to this kind of log line:

```
message repeated 2 times: [ time="2018-02-15T22:37:37Z" level=error msg="couldn't publish log part" component=log_writer err="Exception (504) Reason: \"channel/connection is not open\"" inst=0xc420ae0080 job_id=342066020 job_path=DeclareDesign/estimatr/jobs/342066020 pid=5055 processor=8f1c6ae4-33d0-4fd6-bdd5-cc12da75b96b@5055.wjb-2 repository=DeclareDesign/estimatr self=amqp_log_writer]
```

because we run rsyslog on all workers for shipping logs to papertrail, and we are running with `$RepeatedMsgReduction on`, it adds some padding to repeated messages like such:

```
message repeated 2 times: [ ...]
```

we could disable that everywhere, but it's kind of a nice way to reduce our log volume _especially_ when things are going wrong.

so the proposal instead is to doctor the logs at ingest. this is my first time using perl because i couldn't get the `sed` incantation to work.