### PR TITLE
Add program field for macstadium workers

### DIFF
--- a/tail-com.sh
+++ b/tail-com.sh
@@ -123,7 +123,7 @@ sleep $BOOT_DELAY
         --delay "$PAPERTRAIL_DELAY" \
         --follow \
         --json | \
-      jq -cr '.events[]|"hostname=" + .hostname + " " + .message' | \
+      jq -cr '.events[]|"hostname=" + .hostname + " " + "program=" + .program + " " + .message' | \
       perl -lape 's/message repeated \d+ times: \[ (.*)\]/$1/g' | \
       honeytail \
         --writekey="$HONEYCOMB_WRITEKEY" \

--- a/tail-org.sh
+++ b/tail-org.sh
@@ -123,7 +123,7 @@ sleep $BOOT_DELAY
         --delay "$PAPERTRAIL_DELAY" \
         --follow \
         --json | \
-      jq -cr '.events[]|"hostname=" + .hostname + " " + .message' | \
+      jq -cr '.events[]|"hostname=" + .hostname + " " + "program=" + .program + " " + .message' | \
       perl -lape 's/message repeated \d+ times: \[ (.*)\]/$1/g' | \
       honeytail \
         --writekey="$HONEYCOMB_WRITEKEY" \


### PR DESCRIPTION
Since we don't rely on hostname as much for Macstadium workers, adding the program name (i.e. `travis-worker-production-org-1` could be helpful for debugging).