### PR TITLE
Include `image_name` in papertrail .events to honeycomb 

### DIFF
--- a/tail-com.sh
+++ b/tail-com.sh
@@ -123,7 +123,7 @@ sleep $BOOT_DELAY
         --delay "$PAPERTRAIL_DELAY" \
         --follow \
         --json | \
-      jq -cr '.events[]|"hostname=" + .hostname + " " + "program=" + .program + " " + .message' | \
+      jq -cr '.events[]|"hostname=" + .hostname + " " + "program=" + .program + " " + "image_name=" + .image_name + " " + .message' | \
       perl -lape 's/message repeated \d+ times: \[ (.*)\]/$1/g' | \
       honeytail \
         --writekey="$HONEYCOMB_WRITEKEY" \

--- a/tail-org.sh
+++ b/tail-org.sh
@@ -123,7 +123,7 @@ sleep $BOOT_DELAY
         --delay "$PAPERTRAIL_DELAY" \
         --follow \
         --json | \
-      jq -cr '.events[]|"hostname=" + .hostname + " " + "program=" + .program + " " "image_name=" + .image_name + " " + .message' | \
+      jq -cr '.events[]|"hostname=" + .hostname + " " + "program=" + .program + " " + "image_name=" + .image_name + " " + .message' | \
       perl -lape 's/message repeated \d+ times: \[ (.*)\]/$1/g' | \
       honeytail \
         --writekey="$HONEYCOMB_WRITEKEY" \

--- a/tail-org.sh
+++ b/tail-org.sh
@@ -123,7 +123,7 @@ sleep $BOOT_DELAY
         --delay "$PAPERTRAIL_DELAY" \
         --follow \
         --json | \
-      jq -cr '.events[]|"hostname=" + .hostname + " " + "program=" + .program + " " + .message' | \
+      jq -cr '.events[]|"hostname=" + .hostname + " " + "program=" + .program + " " "image_name=" + .image_name + " " + .message' | \
       perl -lape 's/message repeated \d+ times: \[ (.*)\]/$1/g' | \
       honeytail \
         --writekey="$HONEYCOMB_WRITEKEY" \


### PR DESCRIPTION
Currently the image_name field is empty in honeycomb.  This adds `image_name` to .events, and can help us identify possible correlations between worker processes and xcode images in the macstadium infra.

Thanks! <3 

